### PR TITLE
Changed repository which waydroid pulls from and edited the text in waydroid installer

### DIFF
--- a/qml/Installer.qml
+++ b/qml/Installer.qml
@@ -82,7 +82,7 @@ Page {
             id: dialogueInstall
             title: "Disclaimer!"
             Label {
-                text: i18n.tr("You are about to use an experimental Waydroid installer! <br> Supported devices:") + i18n.tr("<br>Fairephone 3/3+<br>OnePlus 5/5T<br>Pixel/Pixel XL<br>Pixel 2 XL<br>Pixel 3a<br>Poco F1<br>Redmi Note 7/7 Pro/9 Pro/9 Pro Max<br>Samsung Galaxy S10<br>SHIFT6mq<br>Vollaphone (X)<br>") + i18n.tr("Other devices using Halium 9 or above may or may not work as well! <br> There is absolutely no warranty for this to work! Do not use this installer if you dont want to risk to brick your device permenantly (,which is highly unlikely though)!")
+                text: i18n.tr("You are about to use an experimental Waydroid installer! <br> Supported devices:") + i18n.tr("<br>Fairephone 3/3+<br>OnePlus 5/5T<br>Pixel/Pixel XL<br>Pixel 2 XL<br>Pixel 3a<br>Poco F1/M2 Pro<br>Redmi Note 7/7 Pro/9S/9 Pro/9 Pro Max<br>Samsung Galaxy S10<br>SHIFT6mq<br>Vollaphone (X)<br>") + i18n.tr("Other devices using Halium 9 or above may or may not work as well! <br> There is absolutely no warranty for this to work! Do not use this installer if you dont want to risk to brick your device permenantly (,which is highly unlikely though)!")
                 wrapMode: Text.Wrap
             }
 

--- a/src/installer.py
+++ b/src/installer.py
@@ -44,11 +44,11 @@ class Installer:
             if gAPPS == True:
                 print("Initializing waydroid wit GAPPS (downloading lineage)")
                 pyotherside.send('whatState',"=> downloaging LineageOS with GAPPS (This may take a while)")
-                child.sendline("sudo waydroid init -s GAPPS")
+                child.sendline("sudo waydroid init -s GAPPS -c https://waydroid.bardia.tech/OTA/system -v https://waydroid.bardia.tech/OTA/vendor")
             else:
                 print("Initializing waydroid (downloading lineage)")
                 pyotherside.send('whatState',"=> downloaging LineageOS (This may take a while)")
-                child.sendline("sudo waydroid init")
+                child.sendline("sudo waydroid init -c https://waydroid.bardia.tech/OTA/system -v https://waydroid.bardia.tech/OTA/vendor")
         
         def dlstatus():
             print("Download status running")


### PR DESCRIPTION
The reason for the change to a mirror was because of how slow sourceforge is usually taking a long time on fast connections (eventually users think its stuck and give up leading to a corrupted download)
While this is not an issue with a mirror
Added Redmi Note 9S and Poco M2 Pro to the devices string.
