### PR TITLE
Provide some support for custom Android 13 image setup

### DIFF
--- a/po/waydroidhelper.aaronhafer.pot
+++ b/po/waydroidhelper.aaronhafer.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: waydroidhelper.aaronhafer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-12 11:27+0000\n"
+"POT-Creation-Date: 2024-03-27 23:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -70,11 +70,11 @@ msgstr ""
 msgid "Install Waydroid"
 msgstr ""
 
-#: ../qml/Installer.qml:18
+#: ../qml/Installer.qml:19
 msgid "GAPPS"
 msgstr ""
 
-#: ../qml/Installer.qml:32
+#: ../qml/Installer.qml:34
 msgid ""
 "By pressing 'start' the installation will, well... start. The installer will "
 "let you know what it is currently doing. The installation might take a "
@@ -82,89 +82,103 @@ msgid ""
 "this one."
 msgstr ""
 
-#: ../qml/Installer.qml:33
+#: ../qml/Installer.qml:35
 msgid "Installation starting"
 msgstr ""
 
-#: ../qml/Installer.qml:34
+#: ../qml/Installer.qml:36
 msgid "Preparing to download system image (with GAPPS)"
 msgstr ""
 
-#: ../qml/Installer.qml:35
+#: ../qml/Installer.qml:37
 msgid "Preparing to download system image"
 msgstr ""
 
-#: ../qml/Installer.qml:36
+#: ../qml/Installer.qml:38
 msgid "Downloading system image (with GAPPS)"
 msgstr ""
 
-#: ../qml/Installer.qml:37
+#: ../qml/Installer.qml:39
 msgid "Downloading system image"
 msgstr ""
 
-#: ../qml/Installer.qml:38
+#: ../qml/Installer.qml:40
 msgid "Downloading vendor image"
 msgstr ""
 
-#: ../qml/Installer.qml:39
+#: ../qml/Installer.qml:41
 msgid "Validating system image"
 msgstr ""
 
-#: ../qml/Installer.qml:40
+#: ../qml/Installer.qml:42
 msgid "Validating vendor image"
 msgstr ""
 
-#: ../qml/Installer.qml:41
+#: ../qml/Installer.qml:43
 msgid "Extracting system image"
 msgstr ""
 
-#: ../qml/Installer.qml:42
+#: ../qml/Installer.qml:44
 msgid "Extracting vendor image"
 msgstr ""
 
-#: ../qml/Installer.qml:43
+#: ../qml/Installer.qml:45
 msgid "Installation complete!"
 msgstr ""
 
-#: ../qml/Installer.qml:134 ../qml/Main.qml:208 ../qml/Main.qml:414
+#: ../qml/Installer.qml:143 ../qml/Main.qml:208 ../qml/Main.qml:414
 #: ../qml/PasswordPrompt.qml:58 ../qml/Uninstaller.qml:125
 msgid "Ok"
 msgstr ""
 
-#: ../qml/Installer.qml:134 ../qml/Uninstaller.qml:125
+#: ../qml/Installer.qml:143 ../qml/Uninstaller.qml:125
 msgid "Start"
 msgstr ""
 
-#: ../qml/Installer.qml:156
+#: ../qml/Installer.qml:165
 msgid ""
 " <br><br> There is absolutely no warranty for this to work! Do not use this "
 "installer if you dont want to risk to brick your device permenantly (,which "
 "is highly unlikely though)!"
 msgstr ""
 
-#: ../qml/Installer.qml:156
+#: ../qml/Installer.qml:165
 msgid ""
 "You are about to use an experimental Waydroid installer! <br> You can check "
 "if your device is supported on <a href=\"https://devices.ubuntu-touch.io"
 "\">https://devices.ubuntu-touch.io</a>"
 msgstr ""
 
-#: ../qml/Installer.qml:162
+#: ../qml/Installer.qml:171
 msgid "I understand the risk"
 msgstr ""
 
-#: ../qml/Installer.qml:168 ../qml/Installer.qml:211
+#: ../qml/Installer.qml:177 ../qml/Installer.qml:210 ../qml/Installer.qml:253
 #: ../qml/PasswordPrompt.qml:78
 msgid "Cancel"
 msgstr ""
 
-#: ../qml/Installer.qml:197
+#: ../qml/Installer.qml:194
+msgid ""
+"Waydroid doesn't officially support Android versions past 11 (yet). Your "
+"device can still run unofficial Android 13 images (with some additional "
+"bugs) from <a href=\"https://sourceforge.net/projects/aleasto-lineageos/"
+"files/LineageOS 20/waydroid_arm64\">https://sourceforge.net/projects/aleasto-"
+"lineageos/files/LineageOS 20/waydroid_arm64</a> which Waydroid Helper can "
+"setup (excluding GAPPS). <br><br> Do you want to continue?"
+msgstr ""
+
+#: ../qml/Installer.qml:200
+msgid "Yes"
+msgstr ""
+
+#: ../qml/Installer.qml:239
 msgid ""
 "You can install a special version of Waydroid that comes with google apps. "
 "(I personally do not recommend this as it will result in worse privacy.)"
 msgstr ""
 
-#: ../qml/Installer.qml:202
+#: ../qml/Installer.qml:244
 msgid "Enable GAPPS"
 msgstr ""
 

--- a/po/waydroidhelper.aaronhafer.pot
+++ b/po/waydroidhelper.aaronhafer.pot
@@ -137,41 +137,34 @@ msgstr ""
 
 #: ../qml/Installer.qml:156
 msgid ""
-"<br>Fairephone 3/3+<br>OnePlus 5/5T<br>Pixel/Pixel XL<br>Pixel 2 XL<br>Pixel "
-"3a<br>Poco F1<br>Redmi Note 7/7 Pro/9 Pro/9 Pro Max<br>Samsung Galaxy "
-"S10<br>SHIFT6mq<br>Vollaphone (X)<br>"
+" <br><br> There is absolutely no warranty for this to work! Do not use this "
+"installer if you dont want to risk to brick your device permenantly (,which "
+"is highly unlikely though)!"
 msgstr ""
 
 #: ../qml/Installer.qml:156
 msgid ""
-"Other devices using Halium 9 or above may or may not work as well! <br> "
-"There is absolutely no warranty for this to work! Do not use this installer "
-"if you dont want to risk to brick your device permenantly (,which is highly "
-"unlikely though)!"
+"You are about to use an experimental Waydroid installer! <br> You can check "
+"if your device is supported on <a href=\"https://devices.ubuntu-touch.io"
+"\">https://devices.ubuntu-touch.io</a>"
 msgstr ""
 
-#: ../qml/Installer.qml:156
-msgid ""
-"You are about to use an experimental Waydroid installer! <br> Supported "
-"devices:"
-msgstr ""
-
-#: ../qml/Installer.qml:161
+#: ../qml/Installer.qml:162
 msgid "I understand the risk"
 msgstr ""
 
-#: ../qml/Installer.qml:167 ../qml/Installer.qml:210
+#: ../qml/Installer.qml:168 ../qml/Installer.qml:211
 #: ../qml/PasswordPrompt.qml:78
 msgid "Cancel"
 msgstr ""
 
-#: ../qml/Installer.qml:196
+#: ../qml/Installer.qml:197
 msgid ""
 "You can install a special version of Waydroid that comes with google apps. "
 "(I personally do not recommend this as it will result in worse privacy.)"
 msgstr ""
 
-#: ../qml/Installer.qml:201
+#: ../qml/Installer.qml:202
 msgid "Enable GAPPS"
 msgstr ""
 
@@ -205,6 +198,10 @@ msgstr ""
 
 #: ../qml/Main.qml:192
 msgid "Show/Hide"
+msgstr ""
+
+#: ../qml/Main.qml:200
+msgid "Show/Hide apps"
 msgstr ""
 
 #: ../qml/Main.qml:202

--- a/qml/Installer.qml
+++ b/qml/Installer.qml
@@ -153,8 +153,9 @@ Page {
             title: "Disclaimer!"
 
             Label {
-                text: i18n.tr("You are about to use an experimental Waydroid installer! <br> Supported devices:") + i18n.tr("<br>Fairephone 3/3+<br>OnePlus 5/5T<br>Pixel/Pixel XL<br>Pixel 2 XL<br>Pixel 3a<br>Poco F1<br>Redmi Note 7/7 Pro/9 Pro/9 Pro Max<br>Samsung Galaxy S10<br>SHIFT6mq<br>Vollaphone (X)<br>") + i18n.tr("Other devices using Halium 9 or above may or may not work as well! <br> There is absolutely no warranty for this to work! Do not use this installer if you dont want to risk to brick your device permenantly (,which is highly unlikely though)!")
+                text: i18n.tr("You are about to use an experimental Waydroid installer! <br> You can check if your device is supported on <a href=\"https://devices.ubuntu-touch.io\">https://devices.ubuntu-touch.io</a>") + i18n.tr(" <br><br> There is absolutely no warranty for this to work! Do not use this installer if you dont want to risk to brick your device permenantly (,which is highly unlikely though)!")
                 wrapMode: Text.Wrap
+                onLinkActivated: Qt.openUrlExternally(link)
             }
 
             Button {

--- a/src/installer.py
+++ b/src/installer.py
@@ -6,17 +6,43 @@ import sys
 sys.path.append('deps')
 sys.path.append('../deps')
 import pexpect
+import subprocess
+import urllib.request
+import shutil
 
 import password_type
 
 class Installer:
+    click_rootdir = os.getcwd()
+
+    def needs_custom_images(self) -> bool:
+        if os.uname().machine != "aarch64": # images only compiled for arm64
+            return False
+
+        if shutil.which("getprop") is None:
+            return False
+
+        try:
+            vndk = int(subprocess.check_output(["getprop", "ro.vndk.version"]))
+        except ValueError:
+            return False
+
+        if vndk <= 30: # only concerns Android 12, 12L & 13 atm
+            return False
+
+        try:
+            c = urllib.request.urlopen("https://ota.waydro.id/vendor/waydroid_arm64/HALIUM_13.json")
+            c.close()
+            return False
+        except urllib.error.HTTPError as e:
+            return e.code == 404
+
     def get_password_type(self):
         return password_type.get_password_type()
 
-    def install(self,password,gAPPS):
-        
+    def install(self, password, gAPPS, needsCustomImages):
         os.chdir("/home/phablet")
-        
+
         #Starting bash and getting root privileges
         print("Starting bash and getting root privileges")
         pyotherside.send('state', 'starting', False)
@@ -31,15 +57,19 @@ class Installer:
 
         #Initializing waydroid (downloading lineage)
         def download():
-            if gAPPS == True:
-                print("Initializing waydroid wit GAPPS (downloading lineage)")
+            if needsCustomImages:
+                print("Initializing waydroid with custom images (downloading lineage)")
+                pyotherside.send('state', 'dl.init.vanilla', True)
+                child.sendline(f"python3 {self.click_rootdir}/src/waydroid-custom-init")
+            elif gAPPS == True:
+                print("Initializing waydroid with GAPPS (downloading lineage)")
                 pyotherside.send('state', 'dl.init.gapps', True)
                 child.sendline("waydroid init -s GAPPS")
             else:
                 print("Initializing waydroid (downloading lineage)")
                 pyotherside.send('state', 'dl.init.vanilla', True)
                 child.sendline("waydroid init")
-        
+
         def dlstatus():
             print("Download status running")
             downloaded = []
@@ -66,12 +96,12 @@ class Installer:
                         pyotherside.send('state', 'dl.vendor', True)
                     else:
                         pyotherside.send('state', 'dl.gapps' if gAPPS == True else 'dl.vanilla', True)
-                    
+
                     progress = float(child.match.group(1))
                     target = float(child.match.group(2))
                     speed = float(child.match.group(3))
                     unit = child.match.group(4)
-                    
+
                     pyotherside.send('downloadProgress', progress, target, speed, unit)
 
                 index = child.expect(["Validating system image", pexpect.EOF, pexpect.TIMEOUT], timeout=0.5)
@@ -83,10 +113,10 @@ class Installer:
 
                 if 'system' in downloaded and 'vendor' in downloaded:
                     break
-            
+
         trd1 = threading.Thread(target=download)
         trd2 = threading.Thread(target=dlstatus)
-        
+
         trd1.start()
         trd2.start()
 
@@ -97,12 +127,12 @@ class Installer:
         child.close()
 
         pyotherside.send('state', 'complete', False)
-        
+
         return ""
     
     def uninstall(self, password, wipe=False):
         os.chdir("/home/phablet")
-        
+
         #Starting bash and getting root privileges
         print("Starting bash and getting root privileges")
         pyotherside.send('state', 'starting', False)
@@ -126,6 +156,9 @@ class Installer:
         pyotherside.send('state', 'cleanup', False)
         child.sendline("rm -rf /var/lib/waydroid/*")
         child.expect('root.*')
+        if os.path.isdir("/etc/waydroid-extra"):
+            child.sendline("rm -rf {/userdata/system-data,}/etc/waydroid-extra/*")
+            child.expect('root.*')
         child.sendline("rm -f /home/phablet/.local/share/applications/Waydroid.desktop")
         child.expect('root.*')
 

--- a/src/waydroid-custom-init
+++ b/src/waydroid-custom-init
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+import sys
+import os
+import subprocess
+import shutil
+sys.path.insert(1, "/usr/lib/waydroid")
+import tools as waydroid
+
+
+is_bindmnt_setup = os.path.ismount("/etc/waydroid-extra")
+wrapper_script_exists = os.path.exists("/usr/local/bin/waydroid")
+
+
+# make / rw
+was_rw_root = False
+if not (is_bindmnt_setup or wrapper_script_exists):
+    root = os.statvfs('/')
+    if root.f_flag & os.ST_RDONLY:
+        subprocess.run(["mount", "-o", "remount,rw", "/"])
+    else:
+        was_rw_root = True
+
+
+if not is_bindmnt_setup:
+    # use userdata as backing for /etc/waydroid-extra
+    os.makedirs("/userdata/system-data/etc/waydroid-extra", exist_ok=True)
+    os.makedirs("/etc/waydroid-extra", exist_ok=True)
+    subprocess.run(["mount", "-o", "bind", "/userdata/system-data/etc/waydroid-extra", "/etc/waydroid-extra"])
+
+    # make bind-mount survive reboots
+    with open("/etc/system-image/writable-paths", "a") as f:
+        f.write("/etc/waydroid-extra auto persistent none none\n")
+
+
+if not wrapper_script_exists:
+    # workaround having to "double-launch" every UI action
+    with open("/usr/local/bin/waydroid", "w") as f:
+        f.write("""\
+#!/bin/sh
+case "$1" in
+show-full-ui) DOUBLE_LAUNCH=1 ;;
+app)
+    case "$2" in
+    launch|intent) DOUBLE_LAUNCH=1 ;;
+    esac
+esac
+
+if [ "$(pgrep -f '/usr/bin/waydroid (show-full-ui|app (launch|intent))')" ]; then
+    unset DOUBLE_LAUNCH
+fi
+
+[ -z "$DOUBLE_LAUNCH" ] && exec /usr/bin/waydroid "$@"
+
+/usr/bin/waydroid show-full-ui &
+sleep 1
+/usr/bin/waydroid show-full-ui
+wait
+""")
+    os.chmod("/usr/local/bin/waydroid", 0o755)
+
+
+# we're done messing with rootfs
+if not was_rw_root:
+    subprocess.run(["mount", "-o", "remount,ro", "/"])
+
+
+# prep for using waydroid download func similar to tools/__init__.py
+args = waydroid.helpers.arguments()
+args.work = waydroid.config.defaults["work"]
+args.sudo_timer = True
+args.timeout = 1800
+args.log = args.work + "/waydroid.log"
+waydroid.helpers.logging.init(args)
+
+
+if os.path.exists("/etc/waydroid-extra/images/system.img"):
+    print("Already initialized")
+    sys.exit(0)
+
+
+os.makedirs("/etc/waydroid-extra/images", exist_ok=True)
+custom_images_url = "https://sourceforge.net/projects/aleasto-lineageos/files/LineageOS%2020/waydroid_arm64"
+for img in ["system", "vendor"]:
+    downloaded_img = waydroid.helpers.http.download(args, f"{custom_images_url}/{img}.img/download", f"{img}.img", cache=False)
+    print(f"Validating {img} image") # stub
+    print("Extracting to /etc/waydroid-extra/images")
+    shutil.move(downloaded_img, f"/etc/waydroid-extra/images/{img}.img")
+
+
+# start using downloaded custom images
+sys.exit(subprocess.run(["waydroid", "init", "-f"]).returncode)


### PR DESCRIPTION
Consolidates https://gitlab.com/ubports/development/core/packaging/waydroid/-/issues/24 steps into a practical option for people on Halium 12+ ports such as Volla Phone X23.

The problem is `/etc/waydroid-extra` isn't a writable-path by default and will likely disappear on each OTA upgrade; at least simply selecting `Install Waydroid` again should fix this up and not have to download anything if there hasn't been a userdata reset/excplicit Waydroid uninstallation. Should anything be done about this?

Fixes #52.