### PR TITLE
main: update StopApp's icon path for new creation

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -88,7 +88,7 @@ appdrawer = Appdrawer()
 class StopApp:
     def create(self):
         with open("/home/phablet/.local/share/applications/stop-waydroid.desktop", "w") as f:
-            f.write("[Desktop Entry]\nType=Application\nName=Waydroid Stop\nExec=waydroid session stop\nIcon=/usr/lib/waydroid/data/AppIcon.png")
+            f.write("[Desktop Entry]\nType=Application\nName=Waydroid Stop\nExec=waydroid session stop\nIcon=/usr/share/icons/hicolor/512x512/apps/waydroid.png")
     def remove(self):
         if os.path.isfile("/home/phablet/.local/share/applications/stop-waydroid.desktop"):
             os.remove("/home/phablet/.local/share/applications/stop-waydroid.desktop")


### PR DESCRIPTION
The upcoming 20.04 OTA-5 will come with Waydroid 1.4.2, which removes
icon from /usr/lib/waydroid/data/AppIcon.png, leaving only /usr/share/
icons/hicolor/512x512/apps/waydroid.png available (which is also
available on 20.04 OTA-4). This resuilts in missing icon (while the
entry is still there) when the user upgrade their phone to 20.04 OTA-5.

Update main.py to create StopApp icon with the new path. This will fix
the issue for new users and users which come to the app to re-add the
icon. However, it will not fix the issue if the user doesn't come to the
app and re-add the icon.

Bug: https://github.com/Aarontheissueguy/WaydroidHelper/issues/59