### PR TITLE
Broken stopp app icon & not hidable apps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,6 @@
+# Copyright 2022 Marcel Alexandru Nitan
+# https://github.com/nitanmarcel/cinny-click-packaging/blob/main/.github/workflows/build.yml
+
 name: Clickable Build
 
 on: [ push, pull_request ]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,16 +1,14 @@
-# Copyright 2022 Marcel Alexandru Nitan
-# https://github.com/nitanmarcel/cinny-click-packaging/blob/main/.github/workflows/build.yml
-
 name: Clickable Build
 
 on: [ push, pull_request ]
+  workflow_dispatch:
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.2.2
       - name: Install clickable
         run: |
           python3 -m pip install clickable-ut
@@ -18,7 +16,7 @@ jobs:
         run: |
           clickable build
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.4.3
         with:
           name: waydroid_helper_UNCONFINED
           path: build/all/app/*.click

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,6 @@
 name: Clickable Build
 
 on: [ push, pull_request ]
-  workflow_dispatch:
 
 jobs:
   build:

--- a/manifest.json.in
+++ b/manifest.json.in
@@ -9,7 +9,7 @@
             "desktop":  "waydroidhelper.desktop"
         }
     },
-    "version": "3.1.0",
+    "version": "3.1.1",
     "maintainer": "Aaron Hafer <aaronhafer@gmx.de>",
     "framework" : "@CLICK_FRAMEWORK@"
 }

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -334,7 +334,8 @@ MainView {
                     bottom: parent.bottom
                     bottomMargin: 20
                 }
-                color: theme.palette.normal.negative
+                color: theme.palette.normal.raised
+//                color: "cornflowerblue"
                 text: i18n.tr("Renew")
 
                 onClicked: {

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -334,9 +334,10 @@ MainView {
                     bottom: parent.bottom
                     bottomMargin: 20
                 }
-                color: theme.palette.normal.raised
-//                color: "cornflowerblue"
-                text: i18n.tr("Renew")
+//                color: theme.palette.normal.raised
+                color: "cornflowerblue"
+//                text: i18n.tr("Renew")
+                text: i18n.tr("<font color=\"white\">Renew</font>")
 
                 onClicked: {
                     python.call('stopapp.renew', []);

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -328,15 +328,11 @@ MainView {
             Button {
                 id: renewButton
                 anchors {
-//                    left: parent.left
-//                    leftMargin: parent.width / 8
                     horizontalCenter: parent.horizontalCenter
                     bottom: parent.bottom
                     bottomMargin: 20
                 }
-//                color: theme.palette.normal.raised
                 color: "cornflowerblue"
-//                text: i18n.tr("Renew")
                 text: i18n.tr("<font color=\"white\">Renew</font>")
 
                 onClicked: {

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -34,7 +34,7 @@ MainView {
 
     property var inputMethodHints: Qt.ImhHiddenText
     property var isPasswordNumeric: inputMethodHints & Qt.ImhDigitsOnly
-    property alias pycll: python.call
+    property alias pythn: python
 
     function checkAppLifecycleExemption() {
         const appidList = gsettings.lifecycleExemptAppids;
@@ -73,7 +73,7 @@ MainView {
     // cleanup in case it crashes
     Component.onCompleted: {
         unsetAppLifecycleExemption()
-        pycll('stopapp.renew', []);
+        pythn.call('stopapp.renew', []);
     }
     Component.onDestruction: unsetAppLifecycleExemption()
 

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -70,7 +70,10 @@ MainView {
     }
 
     // cleanup in case it crashes
-    Component.onCompleted: unsetAppLifecycleExemption()
+    Component.onCompleted: {
+        unsetAppLifecycleExemption()
+        python.call('stopapp.renew', []);
+    }
     Component.onDestruction: unsetAppLifecycleExemption()
 
     GSettings {
@@ -325,7 +328,7 @@ MainView {
                 }
             }
 
-            Button {
+/*            Button {
                 id: renewButton
                 anchors {
                     horizontalCenter: parent.horizontalCenter
@@ -338,7 +341,7 @@ MainView {
                 onClicked: {
                     python.call('stopapp.renew', []);
                 }
-            }
+            }*/
 
             Button {
                 anchors {

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -326,6 +326,23 @@ MainView {
             }
 
             Button {
+                id: renewButton
+                anchors {
+//                    left: parent.left
+//                    leftMargin: parent.width / 8
+                    horizontalCenter: parent.horizontalCenter
+                    bottom: parent.bottom
+                    bottomMargin: 20
+                }
+                color: theme.palette.normal.negative
+                text: i18n.tr("Renew")
+
+                onClicked: {
+                    python.call('stopapp.renew', []);
+                }
+            }
+
+            Button {
                 anchors {
                     right: parent.right
                     rightMargin: parent.width / 8

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -72,7 +72,7 @@ MainView {
     // cleanup in case it crashes
     Component.onCompleted: {
         unsetAppLifecycleExemption()
-        python.call('stopapp.renew', []);
+        root.python.call('stopapp.renew', []);
     }
     Component.onDestruction: unsetAppLifecycleExemption()
 

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -34,6 +34,7 @@ MainView {
 
     property var inputMethodHints: Qt.ImhHiddenText
     property var isPasswordNumeric: inputMethodHints & Qt.ImhDigitsOnly
+    property alias pycll: python.call
 
     function checkAppLifecycleExemption() {
         const appidList = gsettings.lifecycleExemptAppids;
@@ -72,7 +73,7 @@ MainView {
     // cleanup in case it crashes
     Component.onCompleted: {
         unsetAppLifecycleExemption()
-        root.python.call('stopapp.renew', []);
+        pycll('stopapp.renew', []);
     }
     Component.onDestruction: unsetAppLifecycleExemption()
 

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -34,7 +34,6 @@ MainView {
 
     property var inputMethodHints: Qt.ImhHiddenText
     property var isPasswordNumeric: inputMethodHints & Qt.ImhDigitsOnly
-    property alias pythn: python
 
     function checkAppLifecycleExemption() {
         const appidList = gsettings.lifecycleExemptAppids;
@@ -73,7 +72,7 @@ MainView {
     // cleanup in case it crashes
     Component.onCompleted: {
         unsetAppLifecycleExemption()
-        pythn.call('stopapp.renew', []);
+        python.call('stopapp.renew', []);
     }
     Component.onDestruction: unsetAppLifecycleExemption()
 
@@ -328,21 +327,6 @@ MainView {
                     python.call('stopapp.remove', []);
                 }
             }
-
-/*            Button {
-                id: renewButton
-                anchors {
-                    horizontalCenter: parent.horizontalCenter
-                    bottom: parent.bottom
-                    bottomMargin: 20
-                }
-                color: "cornflowerblue"
-                text: i18n.tr("<font color=\"white\">Renew</font>")
-
-                onClicked: {
-                    python.call('stopapp.renew', []);
-                }
-            }*/
 
             Button {
                 anchors {

--- a/src/main.py
+++ b/src/main.py
@@ -78,13 +78,13 @@ class Appdrawer:
 #                if line.strip("\n") != "NoDisplay=true":
                  if line.strip("\n") not in ("NoDisplay=true","NoDisplay=false"):
                     f.write(line)
-#        with open(abs_path, "r") as in_file:
-#            buf = in_file.readlines()
-#        with open(abs_path, "w") as out_file:
-#            for line in buf:
-#                if line == "; NoDisplay=true\n":
-#                    line = line + "[Desktop Entry]\n"
-#                out_file.write(line)
+        with open(abs_path, "r") as in_file:
+            buf = in_file.readlines()
+        with open(abs_path, "w") as out_file:
+            for line in buf:
+                if line == "; NoDisplay=true\n":
+                    line = line + "[Desktop Entry]\n"
+                out_file.write(line)
 
 #            content = f.read()
 #        re_status = re.search(r"NoDisplay=(true|false)?", content)

--- a/src/main.py
+++ b/src/main.py
@@ -106,7 +106,7 @@ class StopApp:
         if os.path.isfile("/home/phablet/.local/share/applications/stop-waydroid.desktop"):
             with open("/home/phablet/.local/share/applications/stop-waydroid.desktop", "r") as f:
                 content = f.read()
-                if Icon=/usr/lib/waydroid/data/AppIcon.png in content:
+                if "Icon=/usr/lib/waydroid/data/AppIcon.png" in content:
                     os.remove("/home/phablet/.local/share/applications/stop-waydroid.desktop")
                     with open("/home/phablet/.local/share/applications/stop-waydroid.desktop", "w") as f:
                         f.write("[Desktop Entry]\nType=Application\nName=Waydroid Stop\nExec=waydroid session stop\nIcon=/usr/share/icons/hicolor/512x512/apps/waydroid.png")

--- a/src/main.py
+++ b/src/main.py
@@ -97,11 +97,6 @@ class StopApp:
     def remove(self):
         if os.path.isfile("/home/phablet/.local/share/applications/stop-waydroid.desktop"):
             os.remove("/home/phablet/.local/share/applications/stop-waydroid.desktop")
-    #    def renew(self):
-    #        if os.path.isfile("/home/phablet/.local/share/applications/stop-waydroid.desktop"):
-    #            os.remove("/home/phablet/.local/share/applications/stop-waydroid.desktop")
-    #        with open("/home/phablet/.local/share/applications/stop-waydroid.desktop", "w") as f:
-    #            f.write("[Desktop Entry]\nType=Application\nName=Waydroid Stop\nExec=waydroid session stop\nIcon=/usr/share/icons/hicolor/512x512/apps/waydroid.png")
     def renew(self):
         if os.path.isfile("/home/phablet/.local/share/applications/stop-waydroid.desktop"):
             with open("/home/phablet/.local/share/applications/stop-waydroid.desktop", "r") as f:

--- a/src/main.py
+++ b/src/main.py
@@ -97,13 +97,11 @@ class StopApp:
     def remove(self):
         if os.path.isfile("/home/phablet/.local/share/applications/stop-waydroid.desktop"):
             os.remove("/home/phablet/.local/share/applications/stop-waydroid.desktop")
-'''
-    def renew(self):
-        if os.path.isfile("/home/phablet/.local/share/applications/stop-waydroid.desktop"):
-            os.remove("/home/phablet/.local/share/applications/stop-waydroid.desktop")
-        with open("/home/phablet/.local/share/applications/stop-waydroid.desktop", "w") as f:
-            f.write("[Desktop Entry]\nType=Application\nName=Waydroid Stop\nExec=waydroid session stop\nIcon=/usr/share/icons/hicolor/512x512/apps/waydroid.png")
-'''
+    #    def renew(self):
+    #        if os.path.isfile("/home/phablet/.local/share/applications/stop-waydroid.desktop"):
+    #            os.remove("/home/phablet/.local/share/applications/stop-waydroid.desktop")
+    #        with open("/home/phablet/.local/share/applications/stop-waydroid.desktop", "w") as f:
+    #            f.write("[Desktop Entry]\nType=Application\nName=Waydroid Stop\nExec=waydroid session stop\nIcon=/usr/share/icons/hicolor/512x512/apps/waydroid.png")
     def renew(self):
         if os.path.isfile("/home/phablet/.local/share/applications/stop-waydroid.desktop"):
             with open("/home/phablet/.local/share/applications/stop-waydroid.desktop", "r") as f:

--- a/src/main.py
+++ b/src/main.py
@@ -72,16 +72,28 @@ class Appdrawer:
         if not os.path.isfile(abs_path):
             return
         with open(abs_path, "r") as f:
-            content = f.read()
-        re_status = re.search(r"NoDisplay=(true|false)?", content)
-        if not re_status:
-            content += "NoDisplay=true\n"
-        else:
-            hidden = re_status.group(1) == "true"
-            if not hidden:
-                content = re.sub("NoDisplay=false", "NoDisplay=true", content)
+            lines = f.readlines()
         with open(abs_path, "w") as f:
-            f.write(content)
+            for line in lines:
+                if line.strip("\n") != "NoDisplay=(true|false)?":
+                    f.write(line)
+        with open(abs_path, "r") as in_file:
+            buf = in_file.readlines()
+        with open(abs_path, "w") as out_file:
+            for line in buf:
+                if line == "; NoDisplay=true\n":
+                    line = line + "[Desktop Entry]\n"
+                out_file.write(line)
+#            content = f.read()
+#        re_status = re.search(r"NoDisplay=(true|false)?", content)
+#        if not re_status:
+#            content += "NoDisplay=true\n"
+#        else:
+#            hidden = re_status.group(1) == "true"
+#            if not hidden:
+#                content = re.sub("NoDisplay=false", "NoDisplay=true", content)
+#        with open(abs_path, "w") as f:
+#            f.write(content)
 
 appdrawer = Appdrawer()
 

--- a/src/main.py
+++ b/src/main.py
@@ -77,13 +77,14 @@ class Appdrawer:
             for line in lines:
                 if line.strip("\n") != "NoDisplay=(true|false)?":
                     f.write(line)
-        with open(abs_path, "r") as in_file:
-            buf = in_file.readlines()
-        with open(abs_path, "w") as out_file:
-            for line in buf:
-                if line == "; NoDisplay=true\n":
-                    line = line + "[Desktop Entry]\n"
-                out_file.write(line)
+#        with open(abs_path, "r") as in_file:
+#            buf = in_file.readlines()
+#        with open(abs_path, "w") as out_file:
+#            for line in buf:
+#                if line == "; NoDisplay=true\n":
+#                    line = line + "[Desktop Entry]\n"
+#                out_file.write(line)
+
 #            content = f.read()
 #        re_status = re.search(r"NoDisplay=(true|false)?", content)
 #        if not re_status:

--- a/src/main.py
+++ b/src/main.py
@@ -75,7 +75,7 @@ class Appdrawer:
             lines = f.readlines()
         with open(abs_path, "w") as f:
             for line in lines:
-                if line.strip("\n") != "NoDisplay=true":
+                if line.strip("\n") != "NoDisplay=true" or line.strip("\n") != "NoDisplay=false":
                     f.write(line)
 #        with open(abs_path, "r") as in_file:
 #            buf = in_file.readlines()

--- a/src/main.py
+++ b/src/main.py
@@ -88,7 +88,7 @@ appdrawer = Appdrawer()
 class StopApp:
     def create(self):
         with open("/home/phablet/.local/share/applications/stop-waydroid.desktop", "w") as f:
-            f.write("[Desktop Entry]\nType=Application\nName=Waydroid Stop\nExec=waydroid session stop\nIcon=/usr/lib/waydroid/data/AppIcon.png")
+            f.write("[Desktop Entry]\nType=Application\nName=Waydroid Stop\nExec=waydroid session stop\nIcon=/usr/share/icons/hicolor/512x512/apps/waydroid.png")
     def remove(self):
         if os.path.isfile("/home/phablet/.local/share/applications/stop-waydroid.desktop"):
             os.remove("/home/phablet/.local/share/applications/stop-waydroid.desktop")

--- a/src/main.py
+++ b/src/main.py
@@ -75,7 +75,8 @@ class Appdrawer:
             lines = f.readlines()
         with open(abs_path, "w") as f:
             for line in lines:
-                if line.strip("\n") != "NoDisplay=true" or line.strip("\n") != "NoDisplay=false":
+#                if line.strip("\n") != "NoDisplay=true":
+                 if line.strip("\n") not in ("NoDisplay=true","NoDisplay=false"):
                     f.write(line)
 #        with open(abs_path, "r") as in_file:
 #            buf = in_file.readlines()

--- a/src/main.py
+++ b/src/main.py
@@ -56,15 +56,29 @@ class Appdrawer:
         if not os.path.isfile(abs_path):
             return
         with open(abs_path, "r") as f:
-            content = f.read()
-        re_status = re.search(r"NoDisplay=(true|false)?", content)
-        if not re_status:
-            return
-        hidden = re_status.group(1) == "true"
-        if hidden:
-            content = re.sub(r"NoDisplay=true", "NoDisplay=false", content)
-            with open(abs_path, "w") as f:
-                f.write(content)
+            lines = f.readlines()
+        with open(abs_path, "w") as f:
+            for line in lines:
+                 if line.strip("\n") not in ("NoDisplay=true","NoDisplay=false"):
+                    f.write(line)
+        with open(abs_path, "r") as in_file:
+            buf = in_file.readlines()
+        with open(abs_path, "w") as out_file:
+            for line in buf:
+                if line == "[Desktop Entry]\n":
+                    line = line + "NoDisplay=false\n"
+                out_file.write(line)
+
+
+#            content = f.read()
+#        re_status = re.search(r"NoDisplay=(true|false)?", content)
+#        if not re_status:
+#            return
+#        hidden = re_status.group(1) == "true"
+#        if hidden:
+#            content = re.sub(r"NoDisplay=true", "NoDisplay=false", content)
+#            with open(abs_path, "w") as f:
+#                f.write(content)
     
     def hide(self, appname):
         path = self.clean_to_path(appname)
@@ -75,7 +89,6 @@ class Appdrawer:
             lines = f.readlines()
         with open(abs_path, "w") as f:
             for line in lines:
-#                if line.strip("\n") != "NoDisplay=true":
                  if line.strip("\n") not in ("NoDisplay=true","NoDisplay=false"):
                     f.write(line)
         with open(abs_path, "r") as in_file:

--- a/src/main.py
+++ b/src/main.py
@@ -68,17 +68,6 @@ class Appdrawer:
                 if line == "[Desktop Entry]\n":
                     line = line + "NoDisplay=false\n"
                 out_file.write(line)
-
-
-#            content = f.read()
-#        re_status = re.search(r"NoDisplay=(true|false)?", content)
-#        if not re_status:
-#            return
-#        hidden = re_status.group(1) == "true"
-#        if hidden:
-#            content = re.sub(r"NoDisplay=true", "NoDisplay=false", content)
-#            with open(abs_path, "w") as f:
-#                f.write(content)
     
     def hide(self, appname):
         path = self.clean_to_path(appname)
@@ -98,17 +87,6 @@ class Appdrawer:
                 if line == "[Desktop Entry]\n":
                     line = line + "NoDisplay=true\n"
                 out_file.write(line)
-
-#            content = f.read()
-#        re_status = re.search(r"NoDisplay=(true|false)?", content)
-#        if not re_status:
-#            content += "NoDisplay=true\n"
-#        else:
-#            hidden = re_status.group(1) == "true"
-#            if not hidden:
-#                content = re.sub("NoDisplay=false", "NoDisplay=true", content)
-#        with open(abs_path, "w") as f:
-#            f.write(content)
 
 appdrawer = Appdrawer()
 

--- a/src/main.py
+++ b/src/main.py
@@ -75,7 +75,7 @@ class Appdrawer:
             lines = f.readlines()
         with open(abs_path, "w") as f:
             for line in lines:
-                if line.strip("\n") != "NoDisplay=(true|false)?":
+                if line.strip("\n") != "NoDisplay=true":
                     f.write(line)
 #        with open(abs_path, "r") as in_file:
 #            buf = in_file.readlines()

--- a/src/main.py
+++ b/src/main.py
@@ -92,4 +92,9 @@ class StopApp:
     def remove(self):
         if os.path.isfile("/home/phablet/.local/share/applications/stop-waydroid.desktop"):
             os.remove("/home/phablet/.local/share/applications/stop-waydroid.desktop")
+    def renew(self):
+        if os.path.isfile("/home/phablet/.local/share/applications/stop-waydroid.desktop"):
+            os.remove("/home/phablet/.local/share/applications/stop-waydroid.desktop")
+        with open("/home/phablet/.local/share/applications/stop-waydroid.desktop", "w") as f:
+            f.write("[Desktop Entry]\nType=Application\nName=Waydroid Stop\nExec=waydroid session stop\nIcon=/usr/share/icons/hicolor/512x512/apps/waydroid.png")
 stopapp = StopApp()

--- a/src/main.py
+++ b/src/main.py
@@ -97,9 +97,19 @@ class StopApp:
     def remove(self):
         if os.path.isfile("/home/phablet/.local/share/applications/stop-waydroid.desktop"):
             os.remove("/home/phablet/.local/share/applications/stop-waydroid.desktop")
+'''
     def renew(self):
         if os.path.isfile("/home/phablet/.local/share/applications/stop-waydroid.desktop"):
             os.remove("/home/phablet/.local/share/applications/stop-waydroid.desktop")
         with open("/home/phablet/.local/share/applications/stop-waydroid.desktop", "w") as f:
             f.write("[Desktop Entry]\nType=Application\nName=Waydroid Stop\nExec=waydroid session stop\nIcon=/usr/share/icons/hicolor/512x512/apps/waydroid.png")
+'''
+    def renew(self):
+        if os.path.isfile("/home/phablet/.local/share/applications/stop-waydroid.desktop"):
+            with open("/home/phablet/.local/share/applications/stop-waydroid.desktop", "r") as f:
+                content = f.read()
+                if Icon=/usr/lib/waydroid/data/AppIcon.png in content:
+                    os.remove("/home/phablet/.local/share/applications/stop-waydroid.desktop")
+                    with open("/home/phablet/.local/share/applications/stop-waydroid.desktop", "w") as f:
+                        f.write("[Desktop Entry]\nType=Application\nName=Waydroid Stop\nExec=waydroid session stop\nIcon=/usr/share/icons/hicolor/512x512/apps/waydroid.png")
 stopapp = StopApp()

--- a/src/main.py
+++ b/src/main.py
@@ -82,8 +82,8 @@ class Appdrawer:
             buf = in_file.readlines()
         with open(abs_path, "w") as out_file:
             for line in buf:
-                if line == "; NoDisplay=true\n":
-                    line = line + "[Desktop Entry]\n"
+                if line == "[Desktop Entry]\n":
+                    line = line + "NoDisplay=true\n"
                 out_file.write(line)
 
 #            content = f.read()


### PR DESCRIPTION
Hello Aaron,

i tried to solve 2 problems:

- the one with the broken icon:
    - you can create or remove the icon as before
    - if one has installed the last version and the stop app icon is broken the new version will check the *.desktop file and, if the old icon path is still there, remove that file and create a new with the right path

- not hidable apps:
    - some apps are not hidable because there is another section, e.g. "[Desktop Action app_settings]" in the *.desktop file and just appending "NoDisplay=true" to the end of that file will not work
    - with the new version "NoDisplay=true" or "NoDisplay=false" is removed from the *.desktop file and "NoDisplay=true" or "NoDisplay=false" is always inserted after "[Desktop Entry]"
    - only problem is a little delay when loading the app and the stop app icon gets replaced 

This are my ideas, maybe you have better solutions. I have only tested on Fairphone 4 with Ubuntu Touch Focal OTA-6. I don't know why all commits i've made are shown here, it's only correct with/after the last one.