### PR TITLE
Finalize custom Android 13 image setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install clickable
         run: |
           python3 -m pip install clickable-ut
@@ -18,7 +18,7 @@ jobs:
         run: |
           clickable build
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: waydroid_helper_UNCONFINED
           path: build/all/app/*.click

--- a/po/waydroidhelper.aaronhafer.pot
+++ b/po/waydroidhelper.aaronhafer.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: waydroidhelper.aaronhafer\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-03-27 23:26+0000\n"
+"POT-Creation-Date: 2025-06-14 19:57+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -153,32 +153,30 @@ msgstr ""
 msgid "I understand the risk"
 msgstr ""
 
-#: ../qml/Installer.qml:177 ../qml/Installer.qml:210 ../qml/Installer.qml:253
+#: ../qml/Installer.qml:177 ../qml/Installer.qml:209 ../qml/Installer.qml:252
 #: ../qml/PasswordPrompt.qml:78
 msgid "Cancel"
 msgstr ""
 
 #: ../qml/Installer.qml:194
 msgid ""
-"Waydroid doesn't officially support Android versions past 11 (yet). Your "
-"device can still run unofficial Android 13 images (with some additional "
-"bugs) from <a href=\"https://sourceforge.net/projects/aleasto-lineageos/"
-"files/LineageOS 20/waydroid_arm64\">https://sourceforge.net/projects/aleasto-"
-"lineageos/files/LineageOS 20/waydroid_arm64</a> which Waydroid Helper can "
-"setup (excluding GAPPS). <br><br> Do you want to continue?"
+"Waydroid doesn't support OTAs for Android versions past 11 just yet. Your "
+"device can still run the Android 13 images downloaded from the official "
+"SourceForge which Waydroid Helper can setup. <br><br> Do you want to "
+"continue?"
 msgstr ""
 
 #: ../qml/Installer.qml:200
 msgid "Yes"
 msgstr ""
 
-#: ../qml/Installer.qml:239
+#: ../qml/Installer.qml:238
 msgid ""
 "You can install a special version of Waydroid that comes with google apps. "
 "(I personally do not recommend this as it will result in worse privacy.)"
 msgstr ""
 
-#: ../qml/Installer.qml:244
+#: ../qml/Installer.qml:243
 msgid "Enable GAPPS"
 msgstr ""
 

--- a/qml/Installer.qml
+++ b/qml/Installer.qml
@@ -191,7 +191,7 @@ Page {
             title: "Disclaimer!"
 
             Label {
-                text: i18n.tr("Waydroid doesn't officially support Android versions past 11 (yet). Your device can still run unofficial Android 13 images (with some additional bugs) from <a href=\"https://sourceforge.net/projects/aleasto-lineageos/files/LineageOS 20/waydroid_arm64\">https://sourceforge.net/projects/aleasto-lineageos/files/LineageOS 20/waydroid_arm64</a> which Waydroid Helper can setup (excluding GAPPS). <br><br> Do you want to continue?")
+                text: i18n.tr("Waydroid doesn't support OTAs for Android versions past 11 just yet. Your device can still run the Android 13 images downloaded from the official SourceForge which Waydroid Helper can setup. <br><br> Do you want to continue?")
                 wrapMode: Text.Wrap
                 onLinkActivated: Qt.openUrlExternally(link)
             }
@@ -201,7 +201,6 @@ Page {
                 color: theme.palette.normal.negative
                 onClicked: {
                     needsCustomImages = true;
-                    gappsAction.visible = false;
                     PopupUtils.close(dialogueCustom);
                 }
             }

--- a/src/installer.py
+++ b/src/installer.py
@@ -57,18 +57,15 @@ class Installer:
 
         #Initializing waydroid (downloading lineage)
         def download():
-            if needsCustomImages:
-                print("Initializing waydroid with custom images (downloading lineage)")
-                pyotherside.send('state', 'dl.init.vanilla', True)
-                child.sendline(f"python3 {self.click_rootdir}/src/waydroid-custom-init")
-            elif gAPPS == True:
+            waydroid = f"python3 {self.click_rootdir}/src/waydroid-custom-init" if needsCustomImages else "waydroid"
+            if gAPPS == True:
                 print("Initializing waydroid with GAPPS (downloading lineage)")
                 pyotherside.send('state', 'dl.init.gapps', True)
-                child.sendline("waydroid init -s GAPPS")
+                child.sendline(f"{waydroid} init -s GAPPS")
             else:
                 print("Initializing waydroid (downloading lineage)")
                 pyotherside.send('state', 'dl.init.vanilla', True)
-                child.sendline("waydroid init")
+                child.sendline(f"{waydroid} init")
 
         def dlstatus():
             print("Download status running")

--- a/src/waydroid-custom-init
+++ b/src/waydroid-custom-init
@@ -13,32 +13,23 @@ def ver(v):
 
 
 waydroid_ver = subprocess.check_output(["waydroid", "--version"]).decode()
-is_bindmnt_setup = os.path.ismount("/etc/waydroid-extra")
 wrapper_script_needed = ver(waydroid_ver) < ver("1.5.0")
 wrapper_script_exists = os.path.exists("/usr/local/bin/waydroid")
 wrapper_script_changing = wrapper_script_needed is not wrapper_script_exists
+previous_images_path = "/userdata/system-data/etc/waydroid-extra/images"
 
 
 # make / rw
 was_rw_root = False
-if not is_bindmnt_setup or wrapper_script_changing:
+if not os.path.exists("/etc/waydroid-extra") or wrapper_script_changing:
     root = os.statvfs('/')
     if root.f_flag & os.ST_RDONLY:
         subprocess.run(["mount", "-o", "remount,rw", "/"])
     else:
         was_rw_root = True
 
-
-if not is_bindmnt_setup:
-    # use userdata as backing for /etc/waydroid-extra
-    os.makedirs("/userdata/system-data/etc/waydroid-extra", exist_ok=True)
-    os.makedirs("/etc/waydroid-extra", exist_ok=True)
-    subprocess.run(["mount", "-o", "bind", "/userdata/system-data/etc/waydroid-extra", "/etc/waydroid-extra"])
-
-    # make bind-mount survive reboots
-    with open("/etc/system-image/writable-paths", "a") as f:
-        f.write("/etc/waydroid-extra auto persistent none none\n")
-
+# still needed for bind-mount to trick "waydroid init" here
+os.makedirs("/etc/waydroid-extra", exist_ok=True)
 
 if wrapper_script_needed and not wrapper_script_exists:
     # workaround having to "double-launch" every UI action
@@ -68,10 +59,22 @@ wait
 elif not wrapper_script_needed and wrapper_script_exists:
     os.remove("/usr/local/bin/waydroid")
 
-
 # we're done messing with rootfs
 if not was_rw_root:
     subprocess.run(["mount", "-o", "remount,ro", "/"])
+
+
+# any images setup by Waydroid Helper <=3.2.0 are likely unstable, clean them up and setup the new ones below
+if os.path.exists(previous_images_path):
+    shutil.rmtree(previous_images_path)
+
+# avoid potential old /etc/system-image/writable-paths artifact
+if os.path.ismount("/etc/waydroid-extra"):
+    subprocess.run(["umount", "/etc/waydroid-extra"])
+
+# trick "waydroid init" etc for the remainder of this script
+os.makedirs("/var/lib/waydroid/images", exist_ok=True)
+subprocess.run(["mount", "--bind", "/var/lib/waydroid", "/etc/waydroid-extra"])
 
 
 # prep for using waydroid download func similar to tools/__init__.py
@@ -82,13 +85,10 @@ args.timeout = 1800
 args.log = args.work + "/waydroid.log"
 waydroid.helpers.logging.init(args)
 
-
-if os.path.exists("/etc/waydroid-extra/images/vendor.img"):
+if os.path.exists("/var/lib/waydroid/images/vendor.img"):
     print("Already initialized")
     sys.exit(0)
 
-
-os.makedirs("/etc/waydroid-extra/images", exist_ok=True)
 images_url = "https://sourceforge.net/projects/waydroid/files/images"
 system_variant = "GAPPS" if "GAPPS" in sys.argv else "VANILLA"
 images_date = "20250614"
@@ -96,11 +96,16 @@ for img in [f"system/lineage/waydroid_arm64/lineage-20.0-{images_date}-{system_v
             f"vendor/waydroid_arm64/lineage-20.0-{images_date}-HALIUM_13-waydroid_arm64-vendor"]:
     downloaded_zip = waydroid.helpers.http.download(args, f"{images_url}/{img}.zip/download", os.path.basename(f"{img}.zip"), cache=False)
     print(f"Validating {'vendor' if 'vendor' in img else 'system'} image") # stub
-    print("Extracting to /etc/waydroid-extra/images")
+    print("Extracting to /var/lib/waydroid/images")
     with zipfile.ZipFile(downloaded_zip, 'r') as zip_ref:
-        zip_ref.extractall("/etc/waydroid-extra/images")
+        zip_ref.extractall("/var/lib/waydroid/images")
     os.remove(downloaded_zip)
 
 
 # start using downloaded custom images
-sys.exit(subprocess.run(["waydroid", "init", "-f"]).returncode)
+ret = subprocess.run(["waydroid", "init", "-f"]).returncode
+if ret != 0:
+    sys.exit(ret)
+
+# finally keep working by always searching for images in persistent-across-OTAs /var/lib/waydroid/images
+sys.exit(subprocess.run(["sed", "-i", "s:/etc/waydroid-extra/images:/var/lib/waydroid/images:", "/var/lib/waydroid/waydroid.cfg"]).returncode)

--- a/src/waydroid-custom-init
+++ b/src/waydroid-custom-init
@@ -3,6 +3,7 @@ import sys
 import os
 import subprocess
 import shutil
+import zipfile
 sys.path.insert(1, "/usr/lib/waydroid")
 import tools as waydroid
 
@@ -82,18 +83,23 @@ args.log = args.work + "/waydroid.log"
 waydroid.helpers.logging.init(args)
 
 
-if os.path.exists("/etc/waydroid-extra/images/system.img"):
+if os.path.exists("/etc/waydroid-extra/images/vendor.img"):
     print("Already initialized")
     sys.exit(0)
 
 
 os.makedirs("/etc/waydroid-extra/images", exist_ok=True)
-custom_images_url = "https://sourceforge.net/projects/aleasto-lineageos/files/LineageOS%2020/waydroid_arm64"
-for img in ["system", "vendor"]:
-    downloaded_img = waydroid.helpers.http.download(args, f"{custom_images_url}/{img}.img/download", f"{img}.img", cache=False)
-    print(f"Validating {img} image") # stub
+images_url = "https://sourceforge.net/projects/waydroid/files/images"
+system_variant = "GAPPS" if "GAPPS" in sys.argv else "VANILLA"
+images_date = "20250614"
+for img in [f"system/lineage/waydroid_arm64/lineage-20.0-{images_date}-{system_variant}-waydroid_arm64-system",
+            f"vendor/waydroid_arm64/lineage-20.0-{images_date}-HALIUM_13-waydroid_arm64-vendor"]:
+    downloaded_zip = waydroid.helpers.http.download(args, f"{images_url}/{img}.zip/download", os.path.basename(f"{img}.zip"), cache=False)
+    print(f"Validating {'vendor' if 'vendor' in img else 'system'} image") # stub
     print("Extracting to /etc/waydroid-extra/images")
-    shutil.move(downloaded_img, f"/etc/waydroid-extra/images/{img}.img")
+    with zipfile.ZipFile(downloaded_zip, 'r') as zip_ref:
+        zip_ref.extractall("/etc/waydroid-extra/images")
+    os.remove(downloaded_zip)
 
 
 # start using downloaded custom images

--- a/src/waydroid-custom-init
+++ b/src/waydroid-custom-init
@@ -7,13 +7,20 @@ sys.path.insert(1, "/usr/lib/waydroid")
 import tools as waydroid
 
 
+def ver(v):
+    return tuple(map(int, (v.split("."))))
+
+
+waydroid_ver = subprocess.check_output(["waydroid", "--version"]).decode()
 is_bindmnt_setup = os.path.ismount("/etc/waydroid-extra")
+wrapper_script_needed = ver(waydroid_ver) < ver("1.5.0")
 wrapper_script_exists = os.path.exists("/usr/local/bin/waydroid")
+wrapper_script_changing = wrapper_script_needed is not wrapper_script_exists
 
 
 # make / rw
 was_rw_root = False
-if not (is_bindmnt_setup or wrapper_script_exists):
+if not is_bindmnt_setup or wrapper_script_changing:
     root = os.statvfs('/')
     if root.f_flag & os.ST_RDONLY:
         subprocess.run(["mount", "-o", "remount,rw", "/"])
@@ -32,7 +39,7 @@ if not is_bindmnt_setup:
         f.write("/etc/waydroid-extra auto persistent none none\n")
 
 
-if not wrapper_script_exists:
+if wrapper_script_needed and not wrapper_script_exists:
     # workaround having to "double-launch" every UI action
     with open("/usr/local/bin/waydroid", "w") as f:
         f.write("""\
@@ -57,6 +64,8 @@ sleep 1
 wait
 """)
     os.chmod("/usr/local/bin/waydroid", 0o755)
+elif not wrapper_script_needed and wrapper_script_exists:
+    os.remove("/usr/local/bin/waydroid")
 
 
 # we're done messing with rootfs


### PR DESCRIPTION
Since Waydroid 1.5.0 (https://github.com/waydroid/waydroid/commit/6a0d190) one no longer needs the hacky wrapper script to properly launch it on Halium 12/13 devices; drop it starting with 20.04 OTA-9 which also introduces proper A13 support in the form of https://gitlab.com/ubports/development/core/packaging/waydroid/-/merge_requests/22 which should improve stability and fixes various things depending on the service manager binder being functional.

~~I'm still having to sometimes `sudo systemctl restart waydroid-container` to get it starting again which is rather strange..~~ this was fixed by https://gitlab.com/ubports/development/core/packaging/waydroid/-/merge_requests/23

I've since originally creating the PR also switched `waydroid-custom-init` over to using the official `lineage-20` VANILLA/GAPPS system and `HALIUM_13` vendor zips from https://sourceforge.net/projects/waydroid/files/images/ that further fix some known unstabilities with the previous now GAPPS-only images as well as reduce the required download size back to normal.

Last but not least finally move the custom image location over from `/etc/waydroid-extra/images` to just the usual `/var/lib/waydroid/images` with some config trickery; while the old images could be preserved (moved over) I hardly think it's worth it as per the above considering there's no proper way to do this update either then without manually doing an uninstall + install again.